### PR TITLE
Add ability to run customQuery and make the $board_id and $group_id variables protected

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,19 @@ $item_id = $boardColumns = $MondayBoard->on(12121212)->group('group_id')->addIte
 $column_values = [ 'text1' => 'New Value','text2' => 'New other value...' ];
 $boardColumns = $MondayBoard->on(12121212)->group('group_id')->changeMultipleColumnValues($item_id, $column_values );
 
-
+// Run a custom query
+$query = 'boards (ids: 12121212) {
+        groups (ids: group_id) {
+            items {
+              id
+              name
+              column_values {
+                id
+                text
+                title
+              }
+            }
+          }
+        }';
+$items = $MondayBoard->customQuery($query);
 ```

--- a/src/MondayAPI/MondayBoard.php
+++ b/src/MondayAPI/MondayBoard.php
@@ -10,8 +10,8 @@ use TBlack\MondayAPI\Querying\Query;
 
 class MondayBoard extends MondayAPI
 {
-	private $board_id = false;
-	private $group_id = false;
+	protected $board_id = false;
+	protected $group_id = false;
 
 	public function on( Int $board_id )
 	{

--- a/src/MondayAPI/MondayBoard.php
+++ b/src/MondayAPI/MondayBoard.php
@@ -33,10 +33,10 @@ class MondayBoard extends MondayAPI
 			$arguments['ids']=$this->board_id;
 		}
 
-		$boards = Query::create( 
-			Board::$scope, 
-			$Board->getArguments($arguments), 
-			$Board->getFields($fields) 
+		$boards = Query::create(
+			Board::$scope,
+			$Board->getArguments($arguments),
+			$Board->getFields($fields)
 		);
 
 		return $this->request( self::TYPE_QUERY, $boards );
@@ -47,15 +47,15 @@ class MondayBoard extends MondayAPI
 		$Column = new Column();
 		$Board = new Board();
 
-		$columns = Query::create( 
-			Column::$scope, 
-			'', 
-			$Column->getFields($fields) 
+		$columns = Query::create(
+			Column::$scope,
+			'',
+			$Column->getFields($fields)
 		);
 
-		$boards = Query::create( 
-			Board::$scope, 
-			$Board->getArguments(['ids'=>$this->board_id]), 
+		$boards = Query::create(
+			Board::$scope,
+			$Board->getArguments(['ids'=>$this->board_id]),
 			[$columns]
 		);
 
@@ -76,10 +76,10 @@ class MondayBoard extends MondayAPI
 
 		$Item = new Item();
 
-		$create = Query::create( 
-			'create_item', 
-			$Item->getArguments($arguments, Item::$create_item_arguments), 
-			$Item->getFields(['id']) 
+		$create = Query::create(
+			'create_item',
+			$Item->getArguments($arguments, Item::$create_item_arguments),
+			$Item->getFields(['id'])
 		);
 
 		return $this->request(self::TYPE_MUTAT, $create);
@@ -99,14 +99,19 @@ class MondayBoard extends MondayAPI
 
 		$Item = new Item();
 
-		$create = Query::create( 
-			'change_multiple_column_values', 
-			$Item->getArguments($arguments, Item::$change_multiple_column_values), 
-			$Item->getFields(['id']) 
+		$create = Query::create(
+			'change_multiple_column_values',
+			$Item->getArguments($arguments, Item::$change_multiple_column_values),
+			$Item->getFields(['id'])
 		);
 
 		return $this->request(self::TYPE_MUTAT, $create);
 
+	}
+
+	public function customQuery($query)
+	{
+		return $this->request(self::TYPE_QUERY, $query);
 	}
 }
 


### PR DESCRIPTION
I think because the API is not fully developed yet, adding the ability to run a custom query is needed.

Also I've added the board_id and group_id as protected so the API can be extended without the need of having the package forked/etc.

For example I have used the custom query and extended the board to create a service as follows:

```
<?php

namespace App\Lib;

use TBlack\MondayAPI\MondayBoard;

class MondayService extends MondayBoard {

    public function getItems(){
        $query = sprintf('boards (ids: %s) {
        groups (ids: %s) {
            items {
              id
              name
              column_values {
                id
                text
                title
              }
            }
          }
        }', $this->board_id, $this->group_id);

        $result = $this->customQuery($query);

        if (!isset($result['boards'][0]['groups'][0]['items'])){
            return $result;
        }

        return $result['boards'][0]['groups'][0]['items'];
    }

    public function getItemsWithIds(){
        $result = $this->getItems();

        $return = [];
        foreach ($result as $key=>$val){
            $item = [];
            foreach ($val['column_values'] as $k=>$v){
                $item[$v['title']] = $v['text'];
            }

            if (!isset($item['name'])){
                $item['name'] = $val['name'];
            }

            $return[(int) $val['id']] = $item;
        }

        return $return;
    }

}
```

Due to the poor quality of the code above I wouldn't submit this to the main API, but it does work for me and that's why I think adding the ability to extend the class and run a custom query is important. 

PS: I have ideas how to make the above code reasonable, but I do not have the time yet.